### PR TITLE
SG-11264 Add figure include for captioned images and provide example in documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 5197fa73e7599f6dc3665a53e24bb1eba75f038a
+  revision: fffe43ca5461da681655638a0e3e36d0e7dd2999
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: c14602115a1597f47b2926c56bac24f48415e8bf
+  revision: 1f5abcacd0be85819fd830e85afa32c9a471d09c
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 1f5abcacd0be85819fd830e85afa32c9a471d09c
+  revision: 851695a53635bdc36514288c9d0da954a60de54e
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 851695a53635bdc36514288c9d0da954a60de54e
+  revision: b2420f38ab3554391b4faf9cacac84313c442736
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 66fa3d480b84123e19ae11e0d9d73b965bedd276
+  revision: 5197fa73e7599f6dc3665a53e24bb1eba75f038a
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: b2420f38ab3554391b4faf9cacac84313c442736
+  revision: 66fa3d480b84123e19ae11e0d9d73b965bedd276
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -37,7 +37,7 @@ Use the `figure` include when extended formatting or captioning of an image is n
 
 Supported variables include:
   - `src`: The path to the image
-  - `caption`: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
+  - `caption`: An optional image caption.
   - `width`: An optional width that will be appended to the `<img>` element's `style`.
   - `height`: An optional height that will be appended to the `<img>` element's `style`.
   - `style`: An optional value for the `<img>` element's `style`.

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -25,16 +25,17 @@ When including images, figures, screenshots and diagrams, follow these guideline
 - Graphics should be functional in style, typically using grayscales only.
 
 ## Captioning Figures
-- Use the `image` include when extended formatting or captioning of an image is necessary
+Use the `image` include when extended formatting or captioning of an image is necessary
+{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
+{% raw  %}
 ```
 {% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
 ```
-{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
-
-  Supported variables include:
-    - src: The path to the image
-    - caption: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
-    - width: An optional width that will be appended to the `<img>` element's `style`.
-    - height: An optional height that will be appended to the `<img>` element's `style`.
-    - style: An optional value for the `<img>` element's `style`.
-    - dropshadow: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.
+{% endraw  %}
+Supported variables include:
+  - src: The path to the image
+  - caption: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
+  - width: An optional width that will be appended to the `<img>` element's `style`.
+  - height: An optional height that will be appended to the `<img>` element's `style`.
+  - style: An optional value for the `<img>` element's `style`.
+  - dropshadow: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -23,3 +23,18 @@ When including images, figures, screenshots and diagrams, follow these guideline
 - We are not translating any images, so text should be kept to a minimum.
 - Exported images should be 144dpi and stored in png format.
 - Graphics should be functional in style, typically using grayscales only.
+
+## Captioning Figures
+- Use the `image` include when extended formatting or captioning of an image is necessary
+```
+{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
+```
+{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
+
+  Supported variables include:
+    - src: The path to the image
+    - caption: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
+    - width: An optional width that will be appended to the `<img>` element's `style`.
+    - height: An optional height that will be appended to the `<img>` element's `style`.
+    - style: An optional value for the `<img>` element's `style`.
+    - dropshadow: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -36,9 +36,9 @@ Use the `figure` include when extended formatting or captioning of an image is n
 {% endraw  %}
 
 Supported variables include:
-  - src: The path to the image
-  - caption: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
-  - width: An optional width that will be appended to the `<img>` element's `style`.
-  - height: An optional height that will be appended to the `<img>` element's `style`.
-  - style: An optional value for the `<img>` element's `style`.
-  - dropshadow: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.
+  - `src`: The path to the image
+  - `caption`: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.
+  - `width`: An optional width that will be appended to the `<img>` element's `style`.
+  - `height`: An optional height that will be appended to the `<img>` element's `style`.
+  - `style`: An optional value for the `<img>` element's `style`.
+  - `dropshadow`: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -25,13 +25,16 @@ When including images, figures, screenshots and diagrams, follow these guideline
 - Graphics should be functional in style, typically using grayscales only.
 
 ## Captioning Figures
-Use the `image` include when extended formatting or captioning of an image is necessary
-{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
+Use the `figure` include when extended formatting or captioning of an image is necessary:
+
+{% include figure src="../../images/landing-page/dev_icon.png" caption="An example figure." width="100px" %}
+
 {% raw  %}
 ```
-{% include image src="../../images/landing-page/dev_icon.png" caption="An example image." width="100px" %}
+{% include figure src="../../images/landing-page/dev_icon.png" caption="An example figure." width="100px" %}
 ```
 {% endraw  %}
+
 Supported variables include:
   - src: The path to the image
   - caption: An optional image caption.  If omitted, the `<figcaption>` element will be omitted.

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -35,10 +35,10 @@ Use the `figure` include when extended formatting or captioning of an image is n
 ```
 {% endraw  %}
 
-Supported variables include:
+Supported variables:
   - `src`: The path to the image
   - `caption`: An optional image caption.
   - `width`: An optional width that will be appended to the `<img>` element's `style`.
   - `height`: An optional height that will be appended to the `<img>` element's `style`.
   - `style`: An optional value for the `<img>` element's `style`.
-  - `dropshadow`: An optional boolean that disable's the `<img>` element's `box-shadow`.  Default behavior is `true`.
+  - `dropshadow`: An optional boolean that disables the `<img>` element's `box-shadow` when set to `false`.  Default behavior is `true`.


### PR DESCRIPTION
Add an include allowing advanced formatting of images, using the HTML5 `<figure>` tag.