### PR TITLE
SG-12171 Restructure Permalinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   global:
     - DOC_URL=https://developer.shotgunsoftware.com
     - DOC_PATH=/tk-doc-generator
-    - S3_BUCKET=doctest3
-    - S3_WEB_URL=http://doctest3.s3-website.eu-west-2.amazonaws.com
+    - S3_BUCKET=sg-devdocs
+    - S3_WEB_URL=http://sg-devdocs.s3-website-us-east-1.amazonaws.com
 
 cache:
   pip: true

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :jekyll_plugins do
   gem "jekyll-relative-links"
   gem "jekyll-polyglot"
   gem "jekyll-analytics"
-  gem "jekyll-redirect-from"
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
   gem "jekyll-relative-links"
   gem "jekyll-polyglot"
   gem "jekyll-analytics"
+  gem "jekyll-redirect-from"
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-polyglot (1.3.1)
       jekyll (>= 3.0)
+    jekyll-redirect-from (0.14.0)
+      jekyll (~> 3.3)
     jekyll-relative-links (0.5.3)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
@@ -77,6 +79,7 @@ DEPENDENCIES
   jekyll-analytics
   jekyll-feed (~> 0.6)
   jekyll-polyglot
+  jekyll-redirect-from
   jekyll-relative-links
   just-the-docs!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,6 @@ GEM
       jekyll (~> 3.3)
     jekyll-polyglot (1.3.1)
       jekyll (>= 3.0)
-    jekyll-redirect-from (0.14.0)
-      jekyll (~> 3.3)
     jekyll-relative-links (0.5.3)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
@@ -79,7 +77,6 @@ DEPENDENCIES
   jekyll-analytics
   jekyll-feed (~> 0.6)
   jekyll-polyglot
-  jekyll-redirect-from
   jekyll-relative-links
   just-the-docs!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 2922b739e934dce728e7a0b0e44df7bf1795d4f9
+  revision: 54f8f4d79e2c872402f4b3f75693bb3caba44af3
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: b5c01c8099bf1cd75c681561f82885a12a34096d
+  revision: 2922b739e934dce728e7a0b0e44df7bf1795d4f9
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -6,28 +6,28 @@
 
 - caption: authoring
   children:
-  - page: /authoring/
-  - page: /authoring/markdown/
+  - page: authoring
+  - page: authoring-markdown
     children:
     - text: markdown-cheatsheet
       url: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
-  - page: /authoring/figures/
-  - page: /authoring/toc/
+  - page: authoring-figures
+  - page: authoring-toc
     children:
-    - page: /authoring/toc/file-structure/
+    - page: toc-file-structure
       children:
-      - page: /authoring/toc/file-structure/nesting/
-  - page: /authoring/landing-page/
-  - page: /authoring/preview/
+      - page: toc-nesting
+  - page: authoring-landing-page
+  - page: authoring-preview
 
 - caption: setting-up
   children:
-  - page: /installation/integrating/
-  - page: /installation/languages/
+  - page: installation-integrating
+  - page: installation-languages
 
 - caption: developing
   children:
-  - page: /developing/tech-details/
+  - page: developing-tech-details
 
 
 

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -19,6 +19,7 @@
       - page: toc-nesting
   - page: authoring-landing-page
   - page: authoring-preview
+  - page: authoring-page-urls
 
 - caption: setting-up
   children:

--- a/docs/en/authoring.md
+++ b/docs/en/authoring.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Introduction
+pagename: authoring
 permalink: /authoring/
 lang: en
 ---
@@ -19,6 +20,7 @@ header:
 ---
 layout: default
 title: Example title
+pagename: example
 permalink: /example/
 lang: en
 ---
@@ -45,6 +47,7 @@ You can now author all your content in the default language, specified by the `d
 ---
 layout: default
 title: Example title
+pagename: example
 permalink: /example/
 lang: en
 ---
@@ -60,6 +63,7 @@ then your Swedish translation should look like this:
 ---
 layout: default
 title: Exempel-titel
+pagename: example
 permalink: /example/
 lang: sv
 ---

--- a/docs/en/authoring.md
+++ b/docs/en/authoring.md
@@ -2,7 +2,6 @@
 layout: default
 title: Introduction
 pagename: authoring
-permalink: /authoring/
 lang: en
 ---
 
@@ -21,7 +20,6 @@ header:
 layout: default
 title: Example title
 pagename: example
-permalink: /example/
 lang: en
 ---
 
@@ -29,10 +27,8 @@ lang: en
 Normal markdown content follows...
 ```
 
-That's it - now this page will appear under the url `/example/` on your site and will 
+That's it - now this page can be added to your site's table of contents, and will 
 be formatted as well as including in the search.
-
-{% include info title="Permalink Format" content="Note that the permalink includes a trailing slash, and that this is required." %}
 
 ## Multiple languages
 
@@ -48,7 +44,6 @@ You can now author all your content in the default language, specified by the `d
 layout: default
 title: Example title
 pagename: example
-permalink: /example/
 lang: en
 ---
 
@@ -64,7 +59,6 @@ then your Swedish translation should look like this:
 layout: default
 title: Exempel-titel
 pagename: example
-permalink: /example/
 lang: sv
 ---
 
@@ -73,7 +67,7 @@ lang: sv
 Normalt markdown-innehåll följer...
 ```
 
-{% include info title="Common Fields" content="Note how the permalink needs to be the same for both pages and how we have added lang: sv in order to specify that this is the swedish version." %}
+{% include info title="Common Fields" content="Note how the pagename needs to be the same for both pages and how we have added lang: sv in order to specify that this is the swedish version." %}
 
 If a language is missing a page, it will use the `default_lang` version of that page.
 

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Figures and Diagrams
+pagename: authoring-figures
 permalink: /authoring/figures/
 lang: en
 ---

--- a/docs/en/authoring/figures.md
+++ b/docs/en/authoring/figures.md
@@ -2,7 +2,6 @@
 layout: default
 title: Figures and Diagrams
 pagename: authoring-figures
-permalink: /authoring/figures/
 lang: en
 ---
 

--- a/docs/en/authoring/landing_page.md
+++ b/docs/en/authoring/landing_page.md
@@ -2,7 +2,6 @@
 layout: default
 title: Custom Landing Page
 pagename: authoring-landing-page
-permalink: /authoring/landing-page/
 lang: en
 ---
 
@@ -10,7 +9,7 @@ lang: en
 
 The documenation system supports the notion of a custom landing page. The page consists of several different files:
 
-- A markdown file (typically `index.md`) with its `permalink` setting set to `/`.
+- A markdown file (typically `index.md`) with its `pagename` setting set to `index`.
   This file should be using the `landing_page` layout. For an example, see
   [the tk-doc-generator landing page](https://github.com/shotgunsoftware/tk-doc-generator/blob/master/docs/index.md).
 

--- a/docs/en/authoring/landing_page.md
+++ b/docs/en/authoring/landing_page.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Custom Landing Page
+pagename: authoring-landing-page
 permalink: /authoring/landing-page/
 lang: en
 ---

--- a/docs/en/authoring/markdown.md
+++ b/docs/en/authoring/markdown.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Markdown syntax
+pagename: authoring-markdown
 permalink: /authoring/markdown/
 lang: en
 ---
@@ -18,13 +19,17 @@ Every page that should be processed by the system needs to have a header on the 
 ---
 layout: default
 title: My Wonderful Page
-permalink: /my-wonderful-page/
+pagename: my-wonderful-page
 lang: en
 ---
 ```
 
-{% include info title="Permalink syntax" content="Make sure to add the final slash to the permalink." %}
+### Pagenames
 
+The slug key `pagename` is used to provide a unique name for each page. This is used
+when processing the table of contents to find the page each toc entry corresponds to. For this to work properly, pagenames must be unique.
+
+The `lang: en` defines what language the page has been written in and should follow [i18n language codes](https://developer.chrome.com/webstore/i18n).
 
 ### Language Support
 

--- a/docs/en/authoring/markdown.md
+++ b/docs/en/authoring/markdown.md
@@ -2,7 +2,6 @@
 layout: default
 title: Markdown syntax
 pagename: authoring-markdown
-permalink: /authoring/markdown/
 lang: en
 ---
 
@@ -26,10 +25,11 @@ lang: en
 
 ### Pagenames
 
-The slug key `pagename` is used to provide a unique name for each page. This is used
-when processing the table of contents to find the page each toc entry corresponds to. For this to work properly, pagenames must be unique.
+The slug key `pagename` is used to provide a unique name for each page. This pagename is used when processing the table of contents to find the page each entry corresponds to. Additionally, the pagename is used when generating each page's URL UID.
 
-The `lang: en` defines what language the page has been written in and should follow [i18n language codes](https://developer.chrome.com/webstore/i18n).
+A page's `pagename` is only ever used internally, and does not necessarily need to make sense to an end-user.  Instead it should be descriptive to the documentation maintainer(s).
+
+{% include warning title="Pagenames should be unique and static" content="Because the pagename is used as an identifier for the page in the table of contents, pagenames must be unique.  Additionally, since the pagename is used to generate the page's UID, changing the pagename will change the UID and in turn the URL, meaning previously distributed or bookmarked links will no longer work.  For this reason, it is not advisable to change a pagename after the page has gone live." %}
 
 ### Language Support
 

--- a/docs/en/authoring/page_urls.md
+++ b/docs/en/authoring/page_urls.md
@@ -14,3 +14,5 @@ Page URLs are generated automatically at build time based on each page's `pagena
 To make URLs more human-readable, we append the page titles to the URL like so: `https://mydocumentation.mysite.com/78b64024/?title=Page+URLs`.
 
 The value included there does not change which page is requested -- it is only used to make the URL more readable.  This means that changing a page's title will not break existing links, even if they include the old page title.  The page titles are appended in this manner to internal links and links in the table of contents automatically.
+
+When sending a URL to someone else or bookmarking a link you can change the URL after the `?` in any way you like, or remove that portion of the URL altogether; this will not change which page the URL points to.

--- a/docs/en/authoring/page_urls.md
+++ b/docs/en/authoring/page_urls.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Page URLs
+pagename: authoring-page-urls
+lang: en
+---
+
+# Page URLs
+
+Page URLs are generated automatically at build time based on each page's `pagename`.  This allows URLs to remain static and independent of content, even if the title or purpose of a particular page changes.
+
+## Page Titles in URLs
+
+To make URLs more human-readable, we append the page titles to the URL like so: `https://mydocumentation.mysite.com/78b64024/?title=Page+URLs`.
+
+The value included there does not change which page is requested -- it is only used to make the URL more readable.  This means that changing a page's title will not break existing links, even if they include the old page title.  The page titles are appended in this manner to internal links and links in the table of contents automatically.

--- a/docs/en/authoring/preview.md
+++ b/docs/en/authoring/preview.md
@@ -2,7 +2,6 @@
 layout: default
 title: Local Preview
 pagename: authoring-preview
-permalink: /authoring/pereview/
 lang: en
 ---
 

--- a/docs/en/authoring/preview.md
+++ b/docs/en/authoring/preview.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Local Preview
+pagename: authoring-preview
 permalink: /authoring/pereview/
 lang: en
 ---

--- a/docs/en/authoring/toc.md
+++ b/docs/en/authoring/toc.md
@@ -2,7 +2,6 @@
 layout: default
 title: Table of contents
 pagename: authoring-toc
-permalink: /authoring/toc/
 lang: en
 ---
 

--- a/docs/en/authoring/toc.md
+++ b/docs/en/authoring/toc.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Table of contents
+pagename: authoring-toc
 permalink: /authoring/toc/
 lang: en
 ---
@@ -25,32 +26,34 @@ For example, it may look like this:
 ```yaml
 - caption: authoring
   children:
-  - page: /authoring/
-  - page: /authoring/markdown/
+  - page: authoring
+  - page: authoring-markdown
     children:
     - text: markdown-cheatsheet
       url: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
-  - page: /authoring/figures/
-  - page: /authoring/toc/
+  - page: authoring-figures
+  - page: authoring-toc
     children:
-    - page: /authoring/toc/file-structure/
-  - page: /authoring/landing-page/
-  - page: /authoring/preview/
+    - page: toc-file-structure
+      children:
+      - page: toc-nesting
+  - page: authoring-landing-page
+  - page: authoring-preview
 
 - caption: setting-up
   children:
-  - page: /installation/integrating/
-  - page: /installation/languages/
+  - page: installation-integrating
+  - page: installation-languages
 
 - caption: developing
   children:
-  - page: /developing/tech-details/
+  - page: developing-tech-details
 ```
 
 - The `caption` nodes will be displayed as blue, nonclickable headings in the TOC.
 - Each `caption` node has a list of children in a `children` key.
 - Items in this `children` list can either be other documentation pages or extenrnal links.
-- Documentation pages are referenced by their permalink, e.g. `page: /authoring/markdown/`
+- Documentation pages are referenced by their pagename, e.g. `page: authoring-markdown`
 - External links have a `text` and a `url` key to define where they point.
 
 ## Translation

--- a/docs/en/authoring/toc.md
+++ b/docs/en/authoring/toc.md
@@ -16,6 +16,8 @@ To modify the table of contents, you need to change two files:
   languages as a secondary activity. As an example, the japanese
   version of this document would be `docs/_data/ja/toc_text.yml`.
 
+{% include info title="Moving and renaming pages" content="The location of a page in the table of contents, and the page's title ([specified in the slug](../authoring.md)) determine the page's location and name.  Renaming or moving a page is accomplished by changing these values, and not it's pagename, as the pagename is only used internally." %}
+
 ## The toc file
 
 The `docs/_data/toc.yml` defines the structure of the table of contents.

--- a/docs/en/authoring/toc/file-structure.md
+++ b/docs/en/authoring/toc/file-structure.md
@@ -2,13 +2,12 @@
 layout: default
 title: Content Structure
 pagename: toc-file-structure
-permalink: /authoring/toc/file-structure/
 lang: en
 ---
 
 # How to organize markdown files on disk
 
-Markdown files should be organized by language and then by their permalink.
+Markdown files should be organized by language and then by their position in the table of contents.
 
 The top folder structure should always be the language:
 
@@ -31,15 +30,15 @@ The top folder structure should always be the language:
 
 {% include info title="Symmetry" content="The language folders and the image folder should all have the exact same folder structure. This makes translation easy." %}
 
-Inside the `en` folder, items should be organized by permalink. 
+Inside the `en` folder, items should be organized as they are in the table of contents.
 
 ```
 /root-folder
-  |- index.md               # permalink: /
-  |- shotgun.md             # permalink: /shotgun/
+  |- index.md
+  |- shotgun.md
   |- shotgun
-  |    \- event-daemon.md   # permalink: /shotgun/event-daemon/
-  \- toolkit.md             # permalink: /toolkit/
+  |    \- event-daemon.md
+  \- toolkit.md
 ```
 
 

--- a/docs/en/authoring/toc/file-structure.md
+++ b/docs/en/authoring/toc/file-structure.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Content Structure
+pagename: toc-file-structure
 permalink: /authoring/toc/file-structure/
 lang: en
 ---

--- a/docs/en/authoring/toc/file-structure/nesting.md
+++ b/docs/en/authoring/toc/file-structure/nesting.md
@@ -2,7 +2,6 @@
 layout: default
 title: Nesting
 pagename: toc-nesting
-permalink: /authoring/toc/file-structure/nesting/
 lang: en
 ---
 

--- a/docs/en/authoring/toc/file-structure/nesting.md
+++ b/docs/en/authoring/toc/file-structure/nesting.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Nesting
+pagename: toc-nesting
 permalink: /authoring/toc/file-structure/nesting/
 lang: en
 ---

--- a/docs/en/developing/tech-details.md
+++ b/docs/en/developing/tech-details.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Technical Details
+pagename: developing-tech-details
 permalink: /developing/tech-details/
 lang: en
 ---

--- a/docs/en/developing/tech-details.md
+++ b/docs/en/developing/tech-details.md
@@ -2,7 +2,6 @@
 layout: default
 title: Technical Details
 pagename: developing-tech-details
-permalink: /developing/tech-details/
 lang: en
 ---
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,7 @@
 ---
 layout: landing_page
 title: Overview
+pagename: index
 permalink: /
 lang: en
 ---

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -2,7 +2,6 @@
 layout: landing_page
 title: Overview
 pagename: index
-permalink: /
 lang: en
 ---
 

--- a/docs/en/installation/integrating.md
+++ b/docs/en/installation/integrating.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Integrating the Doc Generator
+pagename: installation-integrating
 permalink: /installation/integrating/
 lang: en
 ---

--- a/docs/en/installation/integrating.md
+++ b/docs/en/installation/integrating.md
@@ -2,7 +2,6 @@
 layout: default
 title: Integrating the Doc Generator
 pagename: installation-integrating
-permalink: /installation/integrating/
 lang: en
 ---
 

--- a/docs/en/installation/languages.md
+++ b/docs/en/installation/languages.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Configuring Languages
+pagename: installation-languages
 permalink: /installation/languages/
 lang: en
 ---

--- a/docs/en/installation/languages.md
+++ b/docs/en/installation/languages.md
@@ -2,7 +2,6 @@
 layout: default
 title: Configuring Languages
 pagename: installation-languages
-permalink: /installation/languages/
 lang: en
 ---
 

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -26,7 +26,6 @@ plugins:
   - jekyll-polyglot
   # analytics
   - jekyll-analytics
-  - jekyll-redirect-from
 
 # default i18n configuration
 languages: ["en"]

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -26,7 +26,7 @@ plugins:
   - jekyll-polyglot
   # analytics
   - jekyll-analytics
-
+  - jekyll-redirect-from
 
 # default i18n configuration
 languages: ["en"]

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -43,4 +43,6 @@ exclude: ["tk-doc-generator"]
 #    id: UA-123-456          # Required - replace with your tracking id
 #    anonymizeIp: false      # Optional - Default: false - set to true for anonymized tracking
 
+# Default permalinks will use the generated UID.  For pages where the UID
+# should not be used, permalink can be set in the page slug.
 permalink: /:uid/

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -44,5 +44,4 @@ exclude: ["tk-doc-generator"]
 #    id: UA-123-456          # Required - replace with your tracking id
 #    anonymizeIp: false      # Optional - Default: false - set to true for anonymized tracking
 
-
-
+permalink: /:uid/

--- a/jekyll/_plugins/uid-permalinks.rb
+++ b/jekyll/_plugins/uid-permalinks.rb
@@ -1,0 +1,77 @@
+# Copyright 2019 Autodesk, Inc.  All rights reserved.
+#
+# Use of this software is subject to the terms of the Autodesk license agreement
+# provided at the time of installation or download, or which otherwise accompanies
+# this software in either electronic or hard copy form.
+#
+
+# Error raised when two page UIDs collide, meaning two different pages will
+# have the same URL.
+class PageUIDCollisionException < StandardError
+  def initialize(msg="Page UID hashes collided.")
+    super(msg)
+  end
+end
+
+module Jekyll
+    class Page
+        # Assignment method to expose URL so that we can modify page URLs from
+        # our Generator.
+        def url=(name)
+            @url = name
+        end
+    end
+
+    # Generator plugin that rewrites page permalinks and URLs at build to use
+    # static UIDs for pages, based on the pagename field in the page slug.
+    # This way page UIDs can be trusted to remain unchanged, even if page title
+    # or location in the TOC changes.
+    class PermalinkRewriter < Jekyll::Generator
+        safe true
+        # Set priority to highest, since we're rewriting page URLs and other
+        # plugins depend on these URLs during generation.
+        priority :highest
+
+        def generate(site)
+            # We'll keep track of the consumed hashes so we can detect a
+            # collision.
+            consumed_hashes = []
+            site.pages.each do |item|
+                if item.data["pagename"]
+                    # We'll generate UID urls for all pages with a pagename
+                    # field in their slug.
+                    pagename = item.data["pagename"].to_s
+                    if pagename == "index"
+                        # Special case for root index -- we want it to sit at /,
+                        # not under a hash.
+                        item.data["permalink"] = "/"
+                        item.url = "/"
+                    else
+                        # Generate a hash from the pagename and truncate to 8
+                        # characters for better usability.
+                        uid = Digest::SHA1.hexdigest(pagename)[0..7]
+                        # If hashes collide, raise an exception.
+                        # The likelyhood of a collision with SHA1 truncated to
+                        # 8 chars is very small (around 1 in 1 million,
+                        # see https://stackoverflow.com/questions/51622061).
+                        # If it becomes a problem we could do something here
+                        # to deal with it, however it wouldn't be as simple as
+                        # say shifting the window on the hash, since existing
+                        # URIs can't change when a new page is added that
+                        # collides.
+                        if consumed_hashes.include? uid
+                            raise PageUIDCollisionException.new
+                        end
+                        consumed_hashes << uid
+                        # Copy the site config permalink to use on this page,
+                        # and replace the UID key with the generated UID.
+                        url = site.config["permalink"].dup
+                        url = url.gsub! ":uid", uid
+                        item.data["permalink"] = url
+                        item.url = url
+                    end
+                end
+            end
+        end
+    end
+end

--- a/jekyll/_plugins/uid-permalinks.rb
+++ b/jekyll/_plugins/uid-permalinks.rb
@@ -14,6 +14,8 @@ class PageUIDCollisionException < StandardError
 end
 
 module Jekyll
+
+    # Modify Jekyll's Page class to expose URL for PermalinkRewriter.
     class Page
         # Assignment method to expose URL so that we can modify page URLs from
         # our Generator.

--- a/jekyll/_plugins/uid-permalinks.rb
+++ b/jekyll/_plugins/uid-permalinks.rb
@@ -6,9 +6,13 @@
 #
 
 # Error raised when two page UIDs collide, meaning two different pages will
-# have the same URL.
+# have the same URL.  This can happen when two pages have the same pagename, or
+# (in a very unlikely case) when two hashes generator for different pagenames
+# are the same.
 class PageUIDCollisionException < StandardError
-  def initialize(msg="Page UID hashes collided.")
+  def initialize(msg="Page UID hashes collided.  This can be caused by "\
+    "duplicate pagenames, or (very very rarely) by two pagenames hashing "\
+    "to the same value.")
     super(msg)
   end
 end

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -72,6 +72,10 @@ mkdir -p ${TMP_BUILD_FOLDER}
 echo "Copying source files into '${TMP_FOLDER}'..."
 cp -r ${SOURCE}/* ${TMP_BUILD_FOLDER}
 
+echo "Copying plugins into '${TMP_FOLDER}/_plugins'..."
+mkdir -p ${TMP_BUILD_FOLDER}/_plugins
+cp -nr ${THIS_DIR}/../jekyll/_plugins/* ${TMP_BUILD_FOLDER}/_plugins
+
 echo "Running Sphinx RST -> Markdown build process..."
 python ${THIS_DIR}/build_sphinx.py ${TMP_BUILD_FOLDER}
 


### PR DESCRIPTION
- Add new TOC generation from pagenames (rather than permalinks.)
- Update documentation to reflect changed TOC behavior.
- Add plugin to generate UID URLs during jekyll build.