### PR TITLE
Minor yum, permission and URL fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - python ./travis-generate-docs.py
 
 deploy:
-  # When commiting to master, auto-deploy to github-pages
+  # When committing to master, auto-deploy to github-pages
   # This will copy the contents of the _build folder to gh-pages branch and push
 - provider: pages
   local-dir: ./_build
@@ -53,4 +53,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   on:
     # only do this when on the master branch
-    branch: master
+    branch: fix-build-docs-rwX-yum-clean-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ python:
 
 env:
   global:
-    - DOC_URL=https://developer.shotgunsoftware.com
+    - DOC_URL=https://wwfxuk.github.io
     - DOC_PATH=/tk-doc-generator
-    - S3_BUCKET=sg-devdocs
-    - S3_WEB_URL=http://sg-devdocs.s3-website-us-east-1.amazonaws.com
 
 cache:
   pip: true
@@ -54,4 +52,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   on:
     # only do this when on the master branch
-    branch: master
+    branch: fix-build-docs-rwX-yum-clean-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     - DOC_URL=https://wwfxuk.github.io
     - DOC_PATH=/tk-doc-generator
-    # We don't have S3, seems like it is optional anyways
 
 cache:
   pip: true
@@ -53,4 +52,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   on:
     # only do this when on the master branch
-    branch: fix-build-docs-rwX-yum-clean-all
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - DOC_URL=https://wwfxuk.github.io
     - DOC_PATH=/tk-doc-generator
+    # We don't have S3, seems like it is optional anyways
 
 cache:
   pip: true
@@ -52,4 +53,4 @@ deploy:
   github-token: $GITHUB_TOKEN
   on:
     # only do this when on the master branch
-    branch: fix-build-docs-rwX-yum-clean-all
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ python:
 
 env:
   global:
-    - DOC_URL=https://wwfxuk.github.io
+    - DOC_URL=https://developer.shotgunsoftware.com
     - DOC_PATH=/tk-doc-generator
+    - S3_BUCKET=sg-devdocs
+    - S3_WEB_URL=http://sg-devdocs.s3-website-us-east-1.amazonaws.com
 
 cache:
   pip: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,30 +18,30 @@ LABEL maintainer="toolkit@shotgunsoftware.com"
 RUN yum update -y && \
     yum install -y epel-release && \
     yum install -y \
-    # Generic build packages
-    autoconf \
-    automake \
-    gcc \
-    gcc-c++ \
-    git \
-    libtool \
-    make \
-    nasm \
-    perl-devel \
-    zlib-devel \
-    tar \
-    nc \
-    xz \
-    # sphinx
-    pandoc \
-    # Python libs
-    python-pip \
-    # Ruby
-    libyaml-devel \
-    openssl-devel \
-    libreadline-dev \
-    zlib-devel \
-    python-pyside \
+        # Generic build packages
+        autoconf \
+        automake \
+        gcc \
+        gcc-c++ \
+        git \
+        libtool \
+        make \
+        nasm \
+        perl-devel \
+        zlib-devel \
+        tar \
+        nc \
+        xz \
+        # sphinx
+        pandoc \
+        # Python libs
+        python-pip \
+        # Ruby
+        libyaml-devel \
+        openssl-devel \
+        libreadline-dev \
+        zlib-devel \
+        python-pyside && \
     yum clean all
 
 # Ruby

--- a/docs/_data/en/toc_text.yml
+++ b/docs/_data/en/toc_text.yml
@@ -1,8 +1,9 @@
 # Translated text strings used by the table of contents
-# 
+#
 # For documentation, see https://developer.shotgunsoftware.com/tk-doc-generator/authoring/toc/
 #
 
+overview: Overview
 authoring: Authoring docs
 markdown-cheatsheet: Markdown Format
 setting-up: Installation

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -4,6 +4,10 @@
 #
 #
 
+- caption: overview
+  children:
+  - page: changelog
+
 - caption: authoring
   children:
   - page: authoring

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Change Log/History
+pagename: changelog
+lang: en
+---
+
+Change Log/History
+------------------
+
+See also the [GitHub Releases page][releases]
+
+[releases]: https://github.com/wwfxuk/tk-doc-generator/releases
+
+# v1.0.0+wwfx.0.1.0
+
+Added this change log as well as minor fixes:
+
+## .travis.yml
+
+- Changed to WWFX UK `DOC_URL`
+
+## Dockerfile
+
+- Fixed `yum clean all` from being part of the `yum install` arguments
+
+## build_docs.sh
+
+- Fixed permissions of generated docs from just `root` only
+
+
+# v1.0.0
+
+Initial release from Shotgun, nothing mentioned by Shotgun.

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -16,18 +16,10 @@ See also the [GitHub Releases page][releases]
 
 Added this change log as well as minor fixes:
 
-## .travis.yml
-
-- Changed to WWFX UK `DOC_URL`
-
-## Dockerfile
-
-- Fixed `yum clean all` from being part of the `yum install` arguments
-
-## build_docs.sh
-
-- Fixed permissions of generated docs from just `root` only
-
+- `.travis.yml`: Changed to WWFX UK `DOC_URL`
+- `Dockerfile`: Fixed `yum clean all` from being part of the `yum install` arguments
+- `build_docs.sh`: Fixed permissions of generated docs from just `root` only
+- `travis-generate-docs.py`: Fallback to `DOC_*` before using dummy URL.
 
 # v1.0.0
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -10,13 +10,12 @@ Change Log/History
 
 See also the [GitHub Releases page][releases]
 
-[releases]: https://github.com/wwfxuk/tk-doc-generator/releases
+[releases]: https://github.com/shotgunsoftware/tk-doc-generator/releases
 
-# v1.0.0+wwfx.0.1.0
+# v1.x.x
 
 Added this change log as well as minor fixes:
 
-- `.travis.yml`: Changed to WWFX UK `DOC_URL`
 - `Dockerfile`: Fixed `yum clean all` from being part of the `yum install` arguments
 - `build_docs.sh`: Fixed permissions of generated docs from just `root` only
 - `travis-generate-docs.py`: Fallback to `DOC_*` before using dummy URL.

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -97,6 +97,8 @@ else
     --source "${TMP_BUILD_FOLDER}" --destination "${OUTPUT}"
 fi
 
+# Local preview_docs.sh (Docker): allow non-root users to modify generated docs
+chmod -R 'a+rwX' "${OUTPUT}"
 echo "------------------------------------------------------"
 echo "Build completed."
 echo "------------------------------------------------------"

--- a/travis-generate-docs.py
+++ b/travis-generate-docs.py
@@ -126,6 +126,11 @@ def main():
 
     # first figure out i we are on master or in a PR.
     if current_branch != "master" or inside_pr:
+        # Defaults: No S3, dummy domain url and empty sub-folder path
+        s3_bucket = None
+        target_url = "https://dummy.url.com"
+        target_url_path = "/"
+
         # we are in a PR.
         log.info("Inside a pull request.")
 
@@ -142,11 +147,16 @@ def main():
         else:
             log.warning("No S3_BUCKET and S3_WEB_URL detected in environment. "
                         "No S3 preview will be generated")
-            s3_bucket = None
-            # enter dummy paths so we can at least build
-            # the docs to check for errors
-            target_url = "https://dummy.url.com"
-            target_url_path = "/"
+
+        # Use DOC_* for target
+        if "DOC_URL" in os.environ and "DOC_PATH" in os.environ:
+            log.info("Using DOC_URL/PATH.")
+            target_url = os.environ["DOC_URL"]
+            target_url_path = os.environ["DOC_PATH"]
+        else:
+            log.warning("Using dummy paths so we can at least build the docs "
+                        "to check for errors")
+
 
         target_full_url = "{url}{path}/index.html".format(url=target_url, path=target_url_path)
 

--- a/travis-generate-docs.py
+++ b/travis-generate-docs.py
@@ -163,12 +163,14 @@ def main():
         )
         execute_external_command(doc_command)
 
-        if s3_bucket:
+        aws_access_key = os.getenv("AWS_S3_ACCESS_KEY", default=None)
+        aws_access_token = os.getenv("AWS_S3_ACCESS_TOKEN", default=None)
+        if s3_bucket and aws_access_key and aws_access_token:
             log.info("Uploading build result to S3...")
             s3_client = boto3.client(
                 "s3",
-                aws_access_key_id=os.environ["AWS_S3_ACCESS_KEY"],
-                aws_secret_access_key=os.environ["AWS_S3_ACCESS_TOKEN"]
+                aws_access_key=aws_access_key,
+                aws_access_token=aws_access_token
             )
 
             # note: skip the first slash when uploading to S3


### PR DESCRIPTION
- `Dockerfile`: Fixed `yum clean all` from being part of the `yum install` arguments
- `build_docs.sh`: Fixed permissions of generated docs from just `root` only
- `travis-generate-docs.py`: Fallback to `DOC_*` before using dummy URL.
- [ ] Version to release as? (need to edit `changelog.md`)