### PR TITLE
Use forked jekyll-relative-links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "just-the-docs", :git => 'https://github.com/shotgunsoftware/just-the-docs.g
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
-  gem "jekyll-relative-links"
+  gem "jekyll-relative-links", :git => 'https://github.com/shotgunsoftware/jekyll-relative-links.git'
   gem "jekyll-polyglot"
   gem "jekyll-analytics"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       jekyll (~> 3.8.5)
       rake (~> 12.3.1)
 
+GIT
+  remote: https://github.com/shotgunsoftware/jekyll-relative-links.git
+  revision: a49f14c10af8181a763026b3f4d7ccafe3622609
+  specs:
+    jekyll-relative-links (0.6.0)
+      jekyll (~> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,8 +47,6 @@ GEM
       jekyll (~> 3.3)
     jekyll-polyglot (1.3.1)
       jekyll (>= 3.0)
-    jekyll-relative-links (0.5.3)
-      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (2.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/shotgunsoftware/jekyll-relative-links.git
-  revision: a49f14c10af8181a763026b3f4d7ccafe3622609
+  revision: 1eec0a697826d6e4af57ca526469272a4ee6d07d
   specs:
     jekyll-relative-links (0.6.0)
       jekyll (~> 3.3)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The following folders exist:
 - `ja` - Japanese translated content.
 - `ko` - Korean translated content.
 - `zh_CN` - Chinese translated content.
-- `images` - All images should be located in the images subfolder structure.
+- `en\images`, `ja\images`, ... - All images should be located in images folders, at the same level as the pages those images are used in.  There may be many `images` directories within each language directory, as needed.
 - `_data/en`, `_data/ja`, ... - Site metadata (e.g. landing page content), organized by language. 
 
 ## Content authoring guide

--- a/docs/en/authoring/toc/file-structure.md
+++ b/docs/en/authoring/toc/file-structure.md
@@ -16,7 +16,6 @@ The top folder structure should always be the language:
   |- en
   |- jp
   |- ko
-  |- images
   |- all_langs
   \- _data
 ```
@@ -24,13 +23,12 @@ The top folder structure should always be the language:
 - All english documentation should be in the `en` folder.
 - All japanese documentation should be in the `jp` folder.
 - All korean documentation should be in the `ko` folder.
-- Images are shared across languanges and are stored in an `images` folder.
 - If you have content that is shared across languages (such as pdfs or zips for example), create an `all_langs` folder and organize it there.
 - Special TOC and landing page data is stored inside the `_data` folder.
 
 {% include info title="Symmetry" content="The language folders and the image folder should all have the exact same folder structure. This makes translation easy." %}
 
-Inside the `en` folder, items should be organized as they are in the table of contents.
+Inside the language folder (e.g.  `en`), items should be organized as they are in the table of contents. Images should be stored in an `images` folder at the same level as the page they are used by.  If mulitple pages at that level use images, you may organize the images folder with subdirectories for each page.
 
 ```
 /root-folder
@@ -38,6 +36,9 @@ Inside the `en` folder, items should be organized as they are in the table of co
   |- shotgun.md
   |- shotgun
   |    \- event-daemon.md
+  |- images
+  |    |- toolkit
+  |    \- shotgun
   \- toolkit.md
 ```
 

--- a/docs/en/authoring/toc/file-structure.md
+++ b/docs/en/authoring/toc/file-structure.md
@@ -26,9 +26,7 @@ The top folder structure should always be the language:
 - If you have content that is shared across languages (such as pdfs or zips for example), create an `all_langs` folder and organize it there.
 - Special TOC and landing page data is stored inside the `_data` folder.
 
-{% include info title="Symmetry" content="The language folders and the image folder should all have the exact same folder structure. This makes translation easy." %}
-
-Inside the language folder (e.g.  `en`), items should be organized as they are in the table of contents. Images should be stored in an `images` folder at the same level as the page they are used by.  If mulitple pages at that level use images, you may organize the images folder with subdirectories for each page.
+Inside the language folder (e.g.  `en`), items should be organized as they are in the table of contents. Images should be stored in an `images` folder at the same level as the page they are used by.  If mulitple pages at that level use images, you should organize the images folder with subdirectories for each page.
 
 ```
 /root-folder


### PR DESCRIPTION
Switch jekyll-relative-links to use our fork, in order to allow de-relativization of raw HTML img src attributes.  This is necessary to allow image internationalization because our liquid figure include uses img tags instead of markdown, and these raw HTML elements aren't de-relativized by jekyll-relative-links out of the box.