### PR TITLE
Support for google custom search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: e81615fe5fd8aa3e90d10cfba7abd8b9c982286c
+  revision: 83009beea3d9f99900d6452561ecc6ac5e02296d
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shotgunsoftware/just-the-docs.git
-  revision: 54f8f4d79e2c872402f4b3f75693bb3caba44af3
+  revision: e81615fe5fd8aa3e90d10cfba7abd8b9c982286c
   specs:
     just-the-docs (0.2.1)
       jekyll (~> 3.8.5)

--- a/docs/en/installation/integrating.md
+++ b/docs/en/installation/integrating.md
@@ -170,3 +170,13 @@ build using the `tk-doc-generator`:
 [![Doc Generator](https://img.shields.io/badge/Built%20With-SG%20Doc%20Generator-blue.svg)](http://github.com/shotgunsoftware/tk-doc-generator)
 ```
 
+## Configuring Search
+
+The documentation system supports integration with [Google Custom Search](https://cse.google.com). This makes it easy to integrate site specific search results. This is disabled by default - in order to enable it, set up a google custom search profile and then add its search engine id into the configuration:
+
+```yaml
+# add a google custom search box
+# (see https://developers.google.com/custom-search/docs/element)
+google_custom_search_id: 0156836942234623426942:2l54_vxygup
+```
+

--- a/docs/en/installation/integrating.md
+++ b/docs/en/installation/integrating.md
@@ -177,6 +177,6 @@ The documentation system supports integration with [Google Custom Search](https:
 ```yaml
 # add a google custom search box
 # (see https://developers.google.com/custom-search/docs/element)
-google_custom_search_id: 0156836942234623426942:2l54_vxygup
+google_custom_search_id: your_search_key_here
 ```
 

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -60,3 +60,8 @@ exclude: ["tk-doc-generator"]
 # Default permalinks will use the generated UID.  For pages where the UID
 # should not be used, permalink can be set in the page slug.
 permalink: /:uid/
+
+# add a google custom search box
+# (see https://developers.google.com/custom-search/docs/element)
+# enter a search engine id in order to enable this
+google_custom_search_id: null


### PR DESCRIPTION
Adds support for custom google search, via a new parameter `google_custom_search_id`:

![search](https://user-images.githubusercontent.com/337710/64493894-e4a0d000-d27d-11e9-9fef-f6bc3ae527c0.gif)

Added brief configuration docs:

![image](https://user-images.githubusercontent.com/337710/64494001-3d249d00-d27f-11e9-8bff-c8199f8f7a3f.png)
