### PR TITLE
SG-13614: Fails properly when Jekyll fails to build the site properly

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -61,6 +61,11 @@ exclude: ["tk-doc-generator"]
 # should not be used, permalink can be set in the page slug.
 permalink: /:uid/
 
+# Jekyll should generate a build error rather than continue silently if there is
+# an error in the front matter. This will ensure that CI fails for incorrectly
+# structured front matter and that we don't silently omit pages.
+strict_front_matter: true
+
 # add a google custom search box
 # (see https://developers.google.com/custom-search/docs/element)
 # enter a search engine id in order to enable this

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -98,15 +98,15 @@ else
 fi
 
 if [ ! -f $OUTPUT/index.html ]; then
-    echo
+    echo ""
     echo "Output site index does not exist: ${OUTPUT}/index.html"
     echo "Jekyll build appears to have failed!"
-    echo
+    echo ""
     exit 1
 else
-    echo
+    echo ""
     echo "Output site index exists. Jekyll build appears to have succeeded!"
-    echo
+    echo ""
 fi
 
 echo "------------------------------------------------------"

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -97,6 +97,18 @@ else
     --source "${TMP_BUILD_FOLDER}" --destination "${OUTPUT}"
 fi
 
+if [ ! -f $OUTPUT/index.html ]; then
+    echo
+    echo "Output site index does not exist: ${OUTPUT}/index.html"
+    echo "Jekyll build appears to have failed!"
+    echo
+    exit 1
+else
+    echo
+    echo "Output site index exists. Jekyll build appears to have succeeded!"
+    echo
+fi
+
 echo "------------------------------------------------------"
 echo "Build completed."
 echo "------------------------------------------------------"


### PR DESCRIPTION
The config change causes Jekyll build to stop what it's doing when it runs into errors and raise a proper exception. However, that does NOT cause the `bundle exec jekyll build` call to return non-zero. The upside is that it DOES stop Jekyll from writing the index.html for the site it's building, which means we can check to see if that exists to determine whether the build succeeded or not.