### PR TITLE
Upgrade setuptools to fix broken builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ COPY ./Gemfile /app
 COPY ./Gemfile.lock /app
 COPY ./requirements.txt /app
 
+# Update setuptools to the latest Python 2.7 compatible version.  This is
+# necessary for install of Pygments 2.6.1, which is a dependency of Sphinx.
+RUN pip install --upgrade setuptools==44.0.0
 # Install any needed packages specified in requirements.txt
 RUN pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,6 @@
 # this software in either electronic or hard copy form.
 #
 
-# Update setuptools to the latest Python 2.7 compatible version.  This is
-# necessary for install of Pygments 2.6.1, which is a dependency of Sphinx.
-setuptools==44.0.0
-
 sphinx==1.8.3
 git+git://github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
 boto3==1.9.71

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@
 # this software in either electronic or hard copy form.
 #
 
+# Update setuptools to the latest Python 2.7 compatible version.  This is
+# necessary for install of Pygments 2.6.1, which is a dependency of Sphinx.
+setuptools==44.0.0
+
 sphinx==1.8.3
 git+git://github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
 boto3==1.9.71


### PR DESCRIPTION
A new release of Pygments breaks on setuptools<20.6.0.  Update setuptools to last Python 2 compatible release and version lock there.