### PR TITLE
Fixes preview builds and moves the build process to using Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 language: python
 
 python:
-    - "2.7"
+    - "3.8"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
 install:
   #
   # install pyside - from https://stackoverflow.com/questions/24489588
-  - sudo apt-get install libqt4-dev
-  - pip install PySide --no-index --find-links https://parkin.github.io/python-wheelhouse/;
-  - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
+  # - sudo apt-get install libqt4-dev
+  # - pip install PySide --no-index --find-links https://parkin.github.io/python-wheelhouse/;
+  # - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
   #
   # jekyll dependencies
   - bundle install --deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN yum update -y && \
     # sphinx
     pandoc \
     # Python libs
+    python3 \
     python-pip \
     # Ruby
     libyaml-devel \
@@ -67,7 +68,8 @@ COPY ./Gemfile.lock /app
 COPY ./requirements.txt /app
 
 # Install any needed packages specified in requirements.txt
-RUN pip install -r requirements.txt
+RUN python3 -m pip install -U pip
+RUN pip3 install -r requirements.txt
 
 # note: stay on bundler 1.17 to be travis compatible
 RUN gem install bundler -v 1.17.2 --no-document

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ sphinx==1.8.3
 git+git://github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
 boto3==1.9.71
 ruamel.yaml==0.15.83
+PySide2==5.15.1
 
 # working around travis issue
 # Could not import extension sphinx.builders.linkcheck (exception: No module named ordered_dict)

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -77,7 +77,7 @@ mkdir -p ${TMP_BUILD_FOLDER}/_plugins
 cp -nr ${THIS_DIR}/../jekyll/_plugins/* ${TMP_BUILD_FOLDER}/_plugins
 
 echo "Running Sphinx RST -> Markdown build process..."
-python ${THIS_DIR}/build_sphinx.py ${TMP_BUILD_FOLDER}
+python3 ${THIS_DIR}/build_sphinx.py ${TMP_BUILD_FOLDER}
 
 echo "Running Jekyll to generate html from markdown..."
 

--- a/scripts/build_sphinx.py
+++ b/scripts/build_sphinx.py
@@ -10,7 +10,7 @@ import uuid
 import logging
 import shutil
 import tempfile
-import commands
+import subprocess
 from ruamel.yaml import YAML
 import os
 
@@ -34,18 +34,17 @@ def add_to_pythonpath(path):
 def execute_external_command(cmd):
     """
     Executes the given command line,
-    logs output checks return code.
+    logs output and raises on failure
 
     :param str cmd: Command to execute
     :returns: The output generated
-    :raises: RuntimeError on failure
+    :raises: SubprocessError on failure
     """
     log.info("Executing command '{}'".format(cmd))
-    (exit_code, output) = commands.getstatusoutput(cmd)
+    p = subprocess.Popen(cmd)
+    stdout, stderr = p.communicate()
+    output = "{}\n{}".format(stdout, stderr)
     log.info(output)
-    log.info("Exit code: {}".format(exit_code))
-    if exit_code != 0:
-        raise RuntimeError("External process returned error.")
     return output
 
 

--- a/travis-generate-docs.py
+++ b/travis-generate-docs.py
@@ -64,7 +64,7 @@ def execute_external_command(cmd):
     :raises: SubprocessError on failure
     """
     log.info("Executing command '{}'".format(cmd))
-    p = subprocess.Popen(cmd)
+    p = subprocess.Popen(cmd, shell=True)
     stdout, stderr = p.communicate()
     output = "{}\n{}".format(stdout, stderr)
     log.info(output)
@@ -100,7 +100,7 @@ def main():
     Execute CI operations
     """
     # expected file and build locations
-    this_folder = os.path.dirname(__file__)
+    this_folder = os.path.abspath(os.path.dirname(__file__))
 
     # note - attempt to detect if we are running this for our own
     # ./docs folder or we are a submodule

--- a/travis-generate-docs.py
+++ b/travis-generate-docs.py
@@ -15,7 +15,7 @@ import boto3
 import os
 import sys
 import mimetypes
-import commands
+import subprocess
 
 # set up logging channel for this script
 log = logging.getLogger(__name__)
@@ -57,18 +57,17 @@ def upload_folder_to_s3(s3_bucket, s3_client, src, dst):
 def execute_external_command(cmd):
     """
     Executes the given command line,
-    logs output checks return code.
+    logs output and raises on failure
 
     :param str cmd: Command to execute
     :returns: The output generated
-    :raises: RuntimeError on failure
+    :raises: SubprocessError on failure
     """
     log.info("Executing command '{}'".format(cmd))
-    (exit_code, output) = commands.getstatusoutput(cmd)
+    p = subprocess.Popen(cmd)
+    stdout, stderr = p.communicate()
+    output = "{}\n{}".format(stdout, stderr)
     log.info(output)
-    log.info("Exit code: {}".format(exit_code))
-    if exit_code != 0:
-        raise RuntimeError("External process returned error.")
     return output
 
 


### PR DESCRIPTION
Preview builds were broken due to one (maybe more) of the modules in the requirements.txt seemingly having removed support for Python 2.7.5, which was the system Python installed in the CentOS 7 container that the build process uses. That's resolved by moving the entire process over to using Python 3.