### PR TITLE
Update requirements.txt to comply with github protocol deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 
 sphinx==1.8.3
-git+git://github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
+git+ssh://git@github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
 boto3==1.9.71
 ruamel.yaml==0.15.83
 PySide2==5.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 
 sphinx==1.8.3
-git+ssh://git@github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
+git+https://github.com/manneohrstrom/sphinx-markdown-builder@master#egg=sphinx-markdown-builder
 boto3==1.9.71
 ruamel.yaml==0.15.83
 PySide2==5.15.1


### PR DESCRIPTION
Github will be [deprecating insecure protocols](https://github.blog/2021-09-01-improving-git-protocol-security-github/).  To keep pip install of requirements from failing, update the protocol for packages installed from git to use `https`.